### PR TITLE
create login api

### DIFF
--- a/WebApp/backend/commands.sh
+++ b/WebApp/backend/commands.sh
@@ -1,0 +1,6 @@
+# This script is used to set up the database for the task management application.
+docker run -d -e POSTGRES_DB=tasks-db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password -p 5432:5432 --name task_management_db postgres:latest --network task_management_network
+
+# connect to the PostgreSQL database
+docker exec -it task_management_db psql -U postgres -d tasks-db
+

--- a/WebApp/backend/commonUtil/python/commonUtil/config.py
+++ b/WebApp/backend/commonUtil/python/commonUtil/config.py
@@ -4,13 +4,13 @@ class Config:
     """
     Configuration class for the application.
     """
-    DB_HOST = os.environ.get("DB_HOST")
-    DB_NAME = os.environ.get("DB_NAME")
-    DB_USER = os.environ.get("DB_USER")
-    DB_PASSWORD = os.environ.get("DB_PASSWORD")
+    DB_HOST = os.environ.get("DB_HOST", "task_management_db")
+    DB_NAME = os.environ.get("DB_NAME", "tasks-db")
+    DB_USER = os.environ.get("DB_USER", "postgres")
+    DB_PASSWORD = os.environ.get("DB_PASSWORD", "password")
     DB_PORT = os.environ.get("DB_PORT", "5432")  # Default to 5432 if not set
 
-    JWT_SECRET = os.environ.get("JWT_SECRET")
+    JWT_SECRET = os.environ.get("JWT_SECRET", "1234567890")
 
 
     @classmethod

--- a/WebApp/backend/handlers/auth/login.py
+++ b/WebApp/backend/handlers/auth/login.py
@@ -53,8 +53,10 @@ def lambda_handler(event, context):
             return create_error_response(401, error_messages.INVALID_CREDENTIALS)
             
         user_id, db_user_name, password_hash = user
-        if not bcrypt.checkpw(password.encode('utf-8'), password_hash.encode('utf-8')):
-            return create_error_response(401, error_messages.INVALID_CREDENTIALS)
+
+        # TODO: Uncomment the following lines when bcrypt is used for password hashing
+        # if not bcrypt.checkpw(password.encode('utf-8'), password_hash.encode('utf-8')):
+        #     return create_error_response(401, error_messages.INVALID_CREDENTIALS)
 
         # Generate JWT token
         jwt_token = generate_jwt(payload={"user_id": user_id, "username": db_user_name}, secret=config.JWT_SECRET)

--- a/WebApp/backend/tables.sh
+++ b/WebApp/backend/tables.sh
@@ -1,5 +1,5 @@
 CREATE TABLE users (
-    user_id SERIAL PRIMARY KEY,
+    user_id UUID PRIMARY KEY NOT NULL,
     username VARCHAR(50) UNIQUE NOT NULL,
     email VARCHAR(100) UNIQUE NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
@@ -10,11 +10,27 @@ CREATE TABLE users (
 );
 
 CREATE TABLE tasks (
-    task_id SERIAL PRIMARY KEY,
+    task_id UUID PRIMARY KEY NOT NULL,
     user_id INTEGER REFERENCES users(user_id) ON DELETE CASCADE,
     description VARCHAR(255) NOT NULL,
     due_date DATE,
     status VARCHAR(20) NOT NULL DEFAULT 'pending',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+
+INSERT INTO users (user_id, username, email, password_hash)
+VALUES (
+    'b613bb6c-77e8-439d-890c-f9203f6bc70a',
+    'testuser',
+    'testuser@gmail.com',
+    '$$2b$$12$$examplehash'
+);
+INSERT INTO users (user_id, username, email, password_hash)
+VALUES (
+    'b613bb6c-77e8-439d-890c-f9203f6bc70a',
+    'userabc',
+    'testuser@gmail.com',
+    'abc123456'
 );


### PR DESCRIPTION
This pull request introduces several changes to the backend of the task management application, focusing on database setup, configuration updates, and schema improvements. The most notable changes include adding a script to set up the database, modifying environment variable defaults in the configuration class, updating the database schema to use UUIDs for primary keys, and adding test data. Additionally, a section of the login handler code related to password hashing has been commented out.

### Database Setup and Configuration:

* Added a new script `commands.sh` to set up a PostgreSQL database using Docker. This includes creating a container, connecting to the database, and setting up a network. (`WebApp/backend/commands.sh`, [WebApp/backend/commands.shR1-R6](diffhunk://#diff-7af37d335564858b4052039ac5cdd5977184507db4f5e5398b68c8f6923ddc2dR1-R6))
* Updated the `Config` class to provide default values for database connection settings and the JWT secret, making it easier to run the application in a local environment without setting environment variables. (`WebApp/backend/commonUtil/python/commonUtil/config.py`, [WebApp/backend/commonUtil/python/commonUtil/config.pyL7-R13](diffhunk://#diff-8f345ca5e6325879b75db0d78b3b7e7b215c282c9814d76df166a5114f62b108L7-R13))

### Database Schema Updates:

* Changed the primary key for the `users` and `tasks` tables from `SERIAL` to `UUID`, ensuring better scalability and uniqueness in distributed systems. (`WebApp/backend/tables.sh`, [[1]](diffhunk://#diff-7285c5e922a51e4a10e445c14ebc7cfcf387793c396acd0efb8fdc8fae0002d8L2-R2) [[2]](diffhunk://#diff-7285c5e922a51e4a10e445c14ebc7cfcf387793c396acd0efb8fdc8fae0002d8L13-R36)
* Added test data for the `users` table to facilitate local development and testing. (`WebApp/backend/tables.sh`, [WebApp/backend/tables.shL13-R36](diffhunk://#diff-7285c5e922a51e4a10e445c14ebc7cfcf387793c396acd0efb8fdc8fae0002d8L13-R36))

### Authentication Handler:

* Commented out the bcrypt password verification logic in the login handler, with a TODO note to re-enable it when bcrypt is used for password hashing. This temporarily bypasses password validation. (`WebApp/backend/handlers/auth/login.py`, [WebApp/backend/handlers/auth/login.pyL56-R59](diffhunk://#diff-b5e20f06e03d682378b47b916f1fd40a85f43c4c9e80b84a473f00c0e4660317L56-R59))