### PR TITLE
Implement DELETE task functionality

### DIFF
--- a/CloudFormation/dev_yaml/template-local.yaml
+++ b/CloudFormation/dev_yaml/template-local.yaml
@@ -97,3 +97,22 @@ Resources:
             Method: GET
     Metadata:
       SamResourceId: GetTasksFunction
+
+  DeleteTaskFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../../WebApp/backend/handlers/tasks
+      Handler: delete_task.lambda_handler
+      Timeout: 500
+      Runtime: python3.12
+      Layers:
+        - !Ref LocalPythonLayer
+        - !Ref LocalLambdaCommonLayer
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /task-management/tasks/{task_id}
+            Method: DELETE
+    Metadata:
+      SamResourceId: DeleteTaskFunction

--- a/WebApp/backend/commonUtil/auth.py
+++ b/WebApp/backend/commonUtil/auth.py
@@ -17,3 +17,20 @@ def generate_jwt(payload, secret) -> str:
 def validate_jwt(payload, secret):
     """Validates a JWT and returns the decoded payload."""
     return jwt.decode(payload, secret, algorithms=[app_constants.JWT_ALGORITHM])
+
+
+def extract_token_from_cookie(headers):
+    """Extract JWT token from request cookies or Authorization header."""
+    # Check if token is in cookies
+    cookie_header = headers.get("Cookie") or headers.get("cookie")
+    if cookie_header:
+        for cookie in cookie_header.split(";"):
+            if cookie.strip().startswith("token="):
+                return cookie.strip().split("=")[1]
+    
+    # Check if token is in Authorization header (Bearer token)
+    auth_header = headers.get("Authorization") or headers.get("authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        return auth_header[7:]  # Remove "Bearer " prefix
+    
+    return None

--- a/WebApp/backend/commonUtil/constants/error_messages.py
+++ b/WebApp/backend/commonUtil/constants/error_messages.py
@@ -26,6 +26,9 @@ class ErrorMessages:
     JWT_INVALID = "JWT token is invalid"
     TASK_CREATION_FAILED = "Task creation failed"
     TASK_CREATION_SUCCESS = "Task created successfully"
+    MISSING_TASK_ID = "Task ID is required"
+    TASK_NOT_FOUND = "Task not found"
+    TASK_DELETION_FAILED = "Task deletion failed"
 
 # Singleton instance for convenience
 error_messages = ErrorMessages()

--- a/WebApp/backend/handlers/tasks/delete_task.py
+++ b/WebApp/backend/handlers/tasks/delete_task.py
@@ -1,0 +1,73 @@
+import logging
+import jwt
+
+from commonUtil.response_helpers import create_error_response, create_success_response
+from commonUtil.constants.error_messages import error_messages
+from commonUtil.constants.http_status import http_status
+from commonUtil.db import get_cursor
+from commonUtil.auth import validate_jwt
+from commonUtil.config import config
+from commonUtil.auth import extract_token_from_cookie
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+def lambda_handler(event, context):
+    """
+    AWS Lambda handler for DELETE /tasks/{task_id} endpoint.
+    Deletes a task for the authenticated user.
+
+    Args:
+        event (dict): The Lambda event object containing request details.
+        context (object): The Lambda context object providing runtime information.
+
+    Returns:
+        dict: A response object with status code, body, and headers.
+    """
+    
+    try:
+        # Extract task_id from path parameters
+        task_id = event["pathParameters"].get("task_id")
+        if not task_id:
+            return create_error_response(http_status.BAD_REQUEST, error_messages.MISSING_TASK_ID)
+        
+        # Extract token from cookie
+        token = extract_token_from_cookie(event.get("headers", {}))
+        if not token:
+            return create_error_response(http_status.UNAUTHORIZED, error_messages.MISSING_AUTH_TOKEN)
+        
+        # Verify token and get user_id
+        try:
+            payload = validate_jwt(token, config.JWT_SECRET)
+            user_id = payload.get("user_id")
+            if not user_id:
+                return create_error_response(http_status.UNAUTHORIZED, error_messages.INVALID_CREDENTIALS)
+        except jwt.ExpiredSignatureError:
+            return create_error_response(http_status.UNAUTHORIZED, error_messages.JWT_EXPIRED)
+        except jwt.InvalidTokenError:
+            return create_error_response(http_status.UNAUTHORIZED, error_messages.JWT_INVALID)
+        
+        with get_cursor() as cursor:
+            # Check if the task exists and belongs to the user
+            cursor.execute(
+                "SELECT task_id FROM tasks WHERE task_id = %s AND user_id = %s",
+                (task_id, user_id)
+            )
+            task = cursor.fetchone()
+            
+            if not task:
+                return create_error_response(http_status.NOT_FOUND, error_messages.TASK_NOT_FOUND)
+            
+            # Delete the task
+            cursor.execute(
+                "DELETE FROM tasks WHERE task_id = %s",
+                (task_id,)
+            )
+            cursor.connection.commit()
+            if cursor.rowcount == 0:
+                return create_error_response(http_status.INTERNAL_SERVER_ERROR, error_messages.TASK_DELETION_FAILED)
+            return create_success_response(http_status.OK, {"message": "Task deleted successfully."})
+    except Exception as e:
+        logger.error(f"Error deleting task: {str(e)}")
+        return create_error_response(http_status.INTERNAL_SERVER_ERROR, error_messages.INTERNAL_ERROR.format(str(e)))
+            


### PR DESCRIPTION
This pull request introduces a new feature for task deletion in the backend, including the implementation of a `DeleteTaskFunction` Lambda function, updates to error handling, and utility enhancements. The most important changes are grouped below by theme.

### New Feature: Task Deletion

* Added a new `DeleteTaskFunction` in the `CloudFormation` template to handle the `DELETE /tasks/{task_id}` endpoint. This function uses the `delete_task.lambda_handler` and includes necessary configurations such as runtime, timeout, and layers.
* Implemented the `delete_task.py` Lambda handler to process task deletion requests. It validates the JWT, checks task ownership, and deletes the task from the database. Includes robust error handling for missing task IDs, authentication failures, and database issues.

### Utility Enhancements

* Added a new utility function `extract_token_from_cookie` in `auth.py` to extract JWT tokens from cookies or the `Authorization` header. This is used in the task deletion flow for authentication.

### Error Handling Improvements

* Extended the `ErrorMessages` class with new constants for task deletion-related errors, such as `MISSING_TASK_ID`, `TASK_NOT_FOUND`, and `TASK_DELETION_FAILED`.