### PR TITLE
Send only status field when toggling task's status

### DIFF
--- a/CloudFormation/dev_yaml/template-local.yaml
+++ b/CloudFormation/dev_yaml/template-local.yaml
@@ -132,6 +132,6 @@ Resources:
           Type: Api
           Properties:
             Path: /task-management/tasks/{task_id}
-            Method: PATCH
+            Method: PUT
     Metadata:
       SamResourceId: UpdateTaskFunction

--- a/WebApp/frontend/src/components/tasks/TaskItem.js
+++ b/WebApp/frontend/src/components/tasks/TaskItem.js
@@ -2,7 +2,8 @@ import React from 'react';
 
 const TaskItem = ({ task, onUpdate, onDelete }) => {
   const handleStatusToggle = () => {
-    onUpdate(task.task_id, { ...task, status: task.status === 'pending' ? 'completed' : 'pending' });
+    // Only send the status field that's changing, not the entire task object
+    onUpdate(task.task_id, { status: task.status === 'pending' ? 'completed' : 'pending' });
   };
 
   const handleDelete = () => {


### PR DESCRIPTION
This pull request introduces changes to improve API consistency and optimize the frontend's task update logic. The most significant updates include switching the HTTP method for task updates from `PATCH` to `PUT` in the backend and modifying the frontend's `onUpdate` function to send only the status field instead of the entire task object.

### Backend API changes:
* In `CloudFormation/dev_yaml/template-local.yaml`, the HTTP method for the `UpdateTaskFunction` API endpoint was changed from `PATCH` to `PUT` to align with RESTful conventions for resource updates.

### Frontend task update optimization:
* In `WebApp/frontend/src/components/tasks/TaskItem.js`, the `onUpdate` function was updated to send only the `status` field when toggling a task's status, reducing unnecessary data transfer.